### PR TITLE
Allow indexing redirected pages with header option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,14 +177,14 @@ Alternatively you can navigate to the TNTSearch configuration section and click 
 
 #### Skipping Indexing
 
-> NOTE: That any page that uses a `redirect` page header attribute will be skipped during indexing.
-
 You can explicitly skip a page that is in the index filter by adding this YAML to the page header:
 
 ```
 tntsearch:
     index: false
 ```
+
+> NOTE: That any page that uses a `redirect` page header attribute and is not explicitly allowed will be skipped during indexing.
 
 #### Multi-Language Support
 

--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -332,8 +332,11 @@ class GravTNTSearch
         if (!$page->routable()) {
             throw new \RuntimeException('not routable...');
         }
-        if ($redirect || (isset($header['tntsearch']['index']) && $header['tntsearch']['index'] === false )) {
+        if ($redirect && !(isset($header['tntsearch']['index']) && $header['tntsearch']['index'] === true)) {
             throw new \RuntimeException('redirect only...');
+        }
+        if (isset($header['tntsearch']['index']) && $header['tntsearch']['index'] === false) {
+            throw new \RuntimeException('skipped by user...');
         }
 
         $route = $page->route();


### PR DESCRIPTION
Indexing redirected pages can sometimes be useful if the redirect is used as an alias to access the content of the original page in a section of another page, so the content of the redirected page keeps the same.