### PR TITLE
Making deleteIndex and updateIndex work again

### DIFF
--- a/classes/GravTNTSearch.php
+++ b/classes/GravTNTSearch.php
@@ -11,6 +11,7 @@ use Grav\Common\Uri;
 use Grav\Common\Yaml;
 use Grav\Common\Page\Collection;
 use Grav\Common\Page\Page;
+use Grav\Common\Flex\Types\Pages\PageObject;
 use RocketTheme\Toolbox\Event\Event;
 use RocketTheme\Toolbox\ResourceLocator\UniformResourceLocator;
 use TeamTNT\TNTSearch\Exceptions\IndexNotFoundException;
@@ -255,7 +256,7 @@ class GravTNTSearch
      */
     public function deleteIndex($object)
     {
-        if (!$object instanceof Page) {
+        if (!($object instanceof Page || $object instanceof PageObject)) {
             return;
         }
 
@@ -278,7 +279,7 @@ class GravTNTSearch
      */
     public function updateIndex($object)
     {
-        if (!$object instanceof Page) {
+        if (!($object instanceof Page || $object instanceof PageObject)) {
             return;
         }
 
@@ -300,6 +301,11 @@ class GravTNTSearch
 
             if (is_string($filter['items'])) {
                 $filter['items'] = Yaml::parse($filter['items']);
+            }
+
+            $pages = Grav::instance()['pages'];
+            if (method_exists($pages, 'enablePages')) {
+                $pages->enablePages();
             }
 
             $apage = new Page;


### PR DESCRIPTION
If FlexObjects is used, the onAdminAfterSave event contanins an instance of a PageObject, so the functions updateIndex() and deleteIndex() will stop  after checking if there is an instance of Page.